### PR TITLE
Use --text-md for <code> in Chatbot message

### DIFF
--- a/js/chatbot/static/ChatBot.svelte
+++ b/js/chatbot/static/ChatBot.svelte
@@ -333,6 +333,9 @@
 		padding: var(--spacing-xl) 10px;
 		direction: ltr;
 	}
+  .message-wrap code {
+    font-size: var(--text-md);
+  }
 
 	/* Tables */
 	.message-wrap :global(table),


### PR DESCRIPTION
## Description

Some language models generate code with just triple backticks (<code>```</code>), whereas other models are capable of using triple backticks *with* the name of the language (<code>\`\`\`python</code>).

In the latter case Gradio does syntax highlighting via a different code path and sets `font-size: var(--text-md)`. However, `<code>` without highlighting is by default `--text-lg`, creating visual inconsistency when we're comparing these two cases side by side:

<img width="1492" alt="Screen Shot 2023-08-08 at 3 11 46 PM" src="https://github.com/jaywonchung/gradio/assets/29395896/c02565d3-594a-4a5e-aa1f-1fce909b4188">

After setting `font-size: var(--text-md)` for normal `<code>` elements inside `.message-wrap` it looks like this:

<img width="1495" alt="Screen Shot 2023-08-08 at 3 12 27 PM" src="https://github.com/jaywonchung/gradio/assets/29395896/5c4d7bf6-32e7-460c-b4fc-9138ec63a12d">


PS1. I believe that this is a very small change that doesn't need an issue before a PR. Please let me know otherwise.
PS2. Long code lines not automatically wrapping would be worth a separate issue.
  
